### PR TITLE
Add py38 support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.12
+current_version = 0.0.13
 
 [metadata]
 license_files = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     install_requires=[
         'pandas',
     ],
-    python_requires='>=3.9',
+    python_requires='>=3.8',
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: MIT License',

--- a/stochatreat/__init__.py
+++ b/stochatreat/__init__.py
@@ -9,5 +9,5 @@ Created on Wed Jul 10 12:16:55 2019
 """
 from stochatreat.stochatreat import stochatreat  # noqa: F401
 
-__version__ = '0.0.12'
+__version__ = '0.0.13'
 __author__ = 'Manuel Martinez'

--- a/stochatreat/utils.py
+++ b/stochatreat/utils.py
@@ -1,6 +1,19 @@
+import sys
 from fractions import Fraction
-from math import lcm
 from typing import Iterable
+
+if sum(sys.version_info[:2]) < 12:
+    from functools import reduce
+    from math import gcd
+
+    def lcm(*args):
+        """
+        Helper function to compute the Lowest Common Multiple of a list of
+        integers
+        """
+        return reduce(lambda a, b: a * b // gcd(a, b), args)
+else:
+    from math import lcm
 
 
 def get_lcm_prob_denominators(probs: Iterable[float]):

--- a/stochatreat/utils.py
+++ b/stochatreat/utils.py
@@ -4,7 +4,7 @@ from typing import Iterable
 
 if sum(sys.version_info[:2]) < 12:
     from functools import reduce
-    from math import gcd
+    from math import gcd  # type: ignore
 
     def lcm(*args):
         """
@@ -13,7 +13,7 @@ if sum(sys.version_info[:2]) < 12:
         """
         return reduce(lambda a, b: a * b // gcd(a, b), args)
 else:
-    from math import lcm
+    from math import lcm  # type: ignore
 
 
 def get_lcm_prob_denominators(probs: Iterable[float]):


### PR DESCRIPTION
Adds 3.8 support by selectively using the `lcm` built-in from 3.9