### PR TITLE
Hotfix pandas change

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,4 +42,4 @@ jobs:
           pycodestyle stochatreat
       - name: Test with pytest
         run: |
-          pytest
+          pytest -x

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.13
+current_version = 0.0.14
 
 [metadata]
 license_files = LICENSE

--- a/stochatreat/__init__.py
+++ b/stochatreat/__init__.py
@@ -9,5 +9,5 @@ Created on Wed Jul 10 12:16:55 2019
 """
 from stochatreat.stochatreat import stochatreat  # noqa: F401
 
-__version__ = '0.0.13'
+__version__ = '0.0.14'
 __author__ = 'Manuel Martinez'

--- a/stochatreat/stochatreat.py
+++ b/stochatreat/stochatreat.py
@@ -160,7 +160,10 @@ def stochatreat(data: pd.DataFrame,
                 n=reduced_sizes[x.name],
                 random_state=random_state
             )
-        ).droplevel(level='stratum_id')
+        )
+
+        if len(reduced_sizes) != len(data):
+            data = data.droplevel(level='stratum_id')
 
         assert sum(reduced_sizes) == len(data)
 


### PR DESCRIPTION
Due to an update in `pandas`, an issue arises when we are trying to stratify across a dataset where the number of strata is equal to the number of unique ids. This PR adds a simple condition to check for that to avoid running in to the bug.