### PR TITLE
fix: resolve failing tests with pandas>=2.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,24 +40,19 @@ Source = "https://github.com/manmartgarc/stochatreat/"
 path = "src/stochatreat/__about__.py"
 
 [tool.hatch.envs.default]
-dependencies = [
-  "pytest",
-  "coverage[toml]>=6.5",
-]
+installer = "uv"
+dependencies = ["pytest", "pytest-cov", "pytest-xdist", "coverage[toml]>=6.5"]
 [tool.hatch.envs.default.scripts]
-test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
-cov-report = [
-  "- coverage combine",
-  "coverage report",
-]
-cov = [
-  "test-cov",
-  "cov-report"
-]
+test = "pytest -n auto {args:tests}"
+test-cov = "pytest -n auto --cov {args:tests}"
+cov-report = ["- coverage combine", "coverage report"]
+cov = ["test-cov", "cov-report"]
+
+[tool.hatch.envs.all]
+installer = "uv"
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.types]
 dependencies = ["mypy>=1.0.0"]
@@ -68,32 +63,23 @@ check = "mypy --install-types --non-interactive {args:src/stochatreat tests}"
 source_pkgs = ["stochatreat", "tests"]
 branch = true
 parallel = true
-omit = [
-  "src/stochatreat/__about__.py",
-]
+omit = ["src/stochatreat/__about__.py"]
 
 [tool.coverage.paths]
 stochatreat = ["src/stochatreat", "*/stochatreat/src/stochatreat"]
 tests = ["tests", "*/stochatreat/tests"]
 
 [tool.coverage.report]
-exclude_lines = [
-  "no cov",
-  "if __name__ == .__main__.:",
-  "if TYPE_CHEKCING"
-]
+exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHEKCING"]
 
 [tool.ruff]
 line-length = 79
 
 [tool.ruff.lint]
-ignore = [
-  "TRY003"
-]
+ignore = ["TRY003"]
 
 [tool.mypy]
 check_untyped_defs = true
 show_error_codes = true
 pretty = true
 ignore_missing_imports = true
-

--- a/src/stochatreat/__init__.py
+++ b/src/stochatreat/__init__.py
@@ -1,0 +1,3 @@
+from stochatreat.stochatreat import stochatreat
+
+__all__ = ["stochatreat"]

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,4 @@
+def test_import():
+    from stochatreat import stochatreat
+
+    assert callable(stochatreat)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -240,7 +240,9 @@ def treatments_dict_rand_index():
             "stratum": [0] * 40 + [1] * 30 + [2] * 30,
         }
     )
-    data = data.set_index(pd.Index(np.random.choice(300, 100, replace=False)))
+    data = data.set_index(
+        pd.Index(np.random.choice(300, 100, replace=False)).astype(np.int64)
+    )
     idx_col = "id"
 
     treatments = stochatreat(


### PR DESCRIPTION
Fixes failing tests that were due to a change in
[pandas>=2.2](https://pandas.pydata.org/docs/reference/api/pandas.core.groupby.DataFrameGroupBy.apply.html) related to using `.apply()` on grouped-by objects. Fixes a bunch of warnings related to dubious type mixing within columns. I also finally fixes the import issue due to using the same name everywhere and adds a unit test for verify that the import is not broken again.

It also deprecates 3.8 since it's almost EOL.