### PR TITLE
bugfix: Fix potential treat_mask finite precision error by rounding before cast to int

### DIFF
--- a/src/stochatreat/stochatreat.py
+++ b/src/stochatreat/stochatreat.py
@@ -193,7 +193,7 @@ def stochatreat(
     # produce the assignment mask that we will use to achieve perfect
     # proportions
     treat_mask = np.repeat(
-        treatment_ids, (lcm_prob_denominators * probs_np).astype(int)
+        treatment_ids, (lcm_prob_denominators * probs_np).round().astype(int)
     )
 
     # =========================================================================

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -33,6 +33,11 @@ standard_probs = [
     [2 / 3, 1 / 3],
     [0.9, 0.1],
     [1 / 2, 1 / 3, 1 / 6],
+    [
+        14.28 / 100.0,
+        42.86 / 100.0,
+        42.86 / 100.0,
+    ],  # approximates 1/7, 3/7, 3/7
 ]
 
 # a set of stratum column combinations from the above df fixture to throw at


### PR DESCRIPTION
Due to fp precision error, it's possible for the original calculation `(lcm_prob_denominators * probs_np).astype(int)` as used when constructing the `treat_mask` to end up truncating values, resulting in the wrong size for `treat_mask` and a downstream IndexError.

In the additional `standard_probs` example I added to the unittests, without rounding that would result in `IndexError: index 4999 is out of bounds for axis 0 with size 4999` at `src/stochatreat/stochatreat.py:257` when assigning treatments.