### PR TITLE
feat: add 'none' misfit strategy to leave misfits unassigned

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,8 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). T
 - Add tests for all new features and bug fixes
 - Run `hatch test` to verify
 - Test files live in `tests/` and must not contain docstrings
+- Test function names should be descriptive enough to explain intent without docstrings
+- Use assertion messages to document failure modes: `assert condition, "Explanation of what went wrong"`
 
 ## CI/CD Releases
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ Got an RCT with unequal strata sizes? `stochatreat` handles the messiness for yo
 !!! tip "Why stochatreat?"
     - :material-check-circle: Works with **any number of strata**
     - :material-check-circle: Supports **unequal treatment probabilities**
-    - :material-check-circle: Two misfit strategies: `"stratum"` or `"global"`
+    - :material-check-circle: Three misfit strategies: `"stratum"`, `"global"`, or `"none"`
     - :material-check-circle: Reproducible via `random_state`
     - :material-check-circle: Returns a clean pandas DataFrame — just merge and go
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -19,7 +19,7 @@
 `stochatreat` assigns treatments within each stratum independently. For a given set of treatment probabilities, it:
 
 1. Divides each stratum into the largest possible block that can be split in exact proportion
-2. Assigns treatments to the remainder (*misfits*) using one of two strategies
+2. Assigns treatments to the remainder (*misfits*) using one of three strategies
 
 ### Misfit strategies
 
@@ -27,6 +27,7 @@
 |---|---|
 | `"stratum"` *(default)* | Misfits in each stratum are assigned randomly and independently using the given probabilities |
 | `"global"` | All misfits across strata are pooled into one group and assigned together |
+| `"none"` | Misfits are left unassigned (`treat = NA`) and marked with `stratum_id = NA` for manual handling |
 
 ## Examples
 
@@ -117,6 +118,33 @@ treats = stochatreat(
     size=500,
     random_state=42,
 )
+```
+
+### Manual misfit handling
+
+The `"none"` strategy identifies misfits but leaves their treatment unassigned. This is useful when you want to handle these cases manually:
+
+```python
+# Identify misfits without assigning treatments to them
+treats = stochatreat(
+    data=df,
+    stratum_cols="nhood",
+    treats=2,
+    idx_col="id",
+    random_state=42,
+    misfit_strategy="none",
+)
+
+# Misfits are marked with stratum_id = NA and treat = NA
+misfits = treats[treats["stratum_id"].isna()]
+print(f"Found {len(misfits)} misfits")
+
+# Option 1: Assign all misfits to control
+treats.loc[treats["stratum_id"].isna(), "treat"] = 0
+
+# Option 2: Exclude misfits from the study
+df = df.merge(treats, how="left", on="id")
+df_assigned = df[df["treat"].notna()]
 ```
 
 ## References

--- a/src/stochatreat/stochatreat.py
+++ b/src/stochatreat/stochatreat.py
@@ -49,16 +49,18 @@ def stochatreat(
         size: The size of the sample if you would like to sample from your
             data.
         misfit_strategy: The strategy used to assign misfits. Can be one of
-            'stratum' or 'global'. If 'stratum', will assign misfits randomly
-            and independently within each stratum using probs. If 'global',
-            will group all misfits into one stratum and do a full assignment
-            procedure in this new stratum with local random assignments of the
-            misfits in this stratum.
+            'stratum', 'global', or 'none'. If 'stratum', will assign misfits
+            randomly and independently within each stratum using probs. If
+            'global', will group all misfits into one stratum and do a full
+            assignment procedure in this new stratum with local random
+            assignments of the misfits in this stratum. If 'none', will leave
+            misfits unassigned (treat = NA) and mark them with stratum_id = NA.
 
     Returns:
         pandas.DataFrame with idx_col, treat (treatment assignments) and
         stratum_id (the id of the stratum within which the assignment
-        procedure was carried out) columns.
+        procedure was carried out) columns. Both treat and stratum_id use
+        pandas nullable integer types (Int64) to support NA values.
 
     Examples:
         Single stratum:

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -483,3 +483,25 @@ def test_stochatreat_crossplatform_flakiness():
         21,
         79,
     ], f"assignments:\n{assignments.groupby(['stratum_id', 'treat']).count()}"
+
+
+def test_stochatreat_none_strategy_leaves_misfits_unassigned():
+    df = pd.DataFrame(
+        {"id": range(10), "stratum": [1, 1, 1, 2, 2, 2, 2, 3, 3, 3]}
+    )
+    result = stochatreat(
+        df,
+        "stratum",
+        treats=2,
+        idx_col="id",
+        misfit_strategy="none",
+        random_state=42,
+    )
+    misfits = result[result["stratum_id"].isna()]
+    expected_misfits = (
+        2  # stratum 1: 3%2=1, stratum 2: 4%2=0, stratum 3: 3%2=1
+    )
+    assert len(misfits) == expected_misfits
+    assert misfits["treat"].isna().all()
+    assigned = result[result["stratum_id"].notna()]
+    assert assigned["treat"].notna().all()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -144,7 +144,7 @@ def test_output_treat_col(treatments_dict):
 def test_output_treat_col_dtype(treatments_dict):
     treatments_df = treatments_dict["treatments"]
     assert_msg = "Treatment column is missing"
-    assert treatments_df["treat"].dtype == np.int64, assert_msg
+    assert treatments_df["treat"].dtype == "Int64", assert_msg
 
 
 def test_output_stratum_id_col(treatments_dict):

--- a/tests/test_treatment.py
+++ b/tests/test_treatment.py
@@ -73,7 +73,7 @@ class TestTreatmentAssigner:
     def test_treat_dtype(self, spec_equal_probs, prepared_df):
         df, idx_col = prepared_df
         result = TreatmentAssigner(spec_equal_probs).assign(df, idx_col)
-        assert result["treat"].dtype == np.int64
+        assert result["treat"].dtype == "Int64"
 
     def test_no_null_treats(self, spec_equal_probs, prepared_df):
         df, idx_col = prepared_df


### PR DESCRIPTION
Add new misfit_strategy option 'none' that leaves misfits unassigned (treat = NA) and marks them with stratum_id = inf. This allows users to identify and handle misfits manually.

- Add NoneMisfitHandler class
- Extract common misfit extraction logic into _extract_misfits helper
- Refactor make_misfit_handler to use dict mapping
- Update TreatmentAssigner to exclude misfits from assignment
- Add unit and integration tests
- Update documentation

Closes #23